### PR TITLE
fix: resolving date compatibility with CreateDateColumn

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "jest --passWithNoTests",
     "lint": "eslint .",
     "lint:webapp": "eslint webapp",
-    "lint:server": "eslint server"
+    "lint:server": "eslint server",
+    "dockerize": "docker compose up --build --force-recreate -d"
   },
   "dependencies": {
     "@elemaudio/core": "^4.0.1",

--- a/server/src/config/entities/DirectMessage.ts
+++ b/server/src/config/entities/DirectMessage.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 import { User } from "./User";
 
 @Entity()
@@ -15,10 +21,10 @@ export class DirectMessage {
   @Column("text")
   body: string;
 
-  @Column({ type: "datetime", default: () => "CURRENT_TIMESTAMP" })
+  @CreateDateColumn()
   createdAt: Date;
 
-  @Column({ type: "datetime", default: () => "CURRENT_TIMESTAMP" })
+  @CreateDateColumn()
   updatedAt: Date;
 
   @Column({ default: true })

--- a/server/src/config/entities/Post.ts
+++ b/server/src/config/entities/Post.ts
@@ -4,6 +4,7 @@ import {
   OneToMany,
   ManyToMany,
   Column,
+  CreateDateColumn,
 } from "typeorm";
 import { User } from "./User";
 import { Tag } from "./Tag";
@@ -22,10 +23,10 @@ export class Post {
   @Column("text")
   body: string;
 
-  @Column({ type: "datetime", default: () => "CURRENT_TIMESTAMP" })
+  @CreateDateColumn()
   createdAt: Date;
 
-  @Column({ type: "datetime", default: () => "CURRENT_TIMESTAMP" })
+  @CreateDateColumn()
   updatedAt: Date;
 
   @Column({ default: true })

--- a/server/src/config/entities/Subscription.ts
+++ b/server/src/config/entities/Subscription.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 import { User } from "./User";
 
 @Entity()
@@ -18,10 +24,10 @@ export class Subscription {
   @Column({ type: "decimal", precision: 10, scale: 2 })
   price: number;
 
-  @Column({ type: "datetime", default: () => "CURRENT_TIMESTAMP" })
+  @CreateDateColumn()
   createdAt: Date;
 
-  @Column({ type: "datetime", default: () => "CURRENT_TIMESTAMP" })
+  @CreateDateColumn()
   updatedAt: Date;
 
   @Column({ default: true })

--- a/server/src/config/entities/Tag.ts
+++ b/server/src/config/entities/Tag.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToMany,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 import { Post } from "./Post";
 
 @Entity()
@@ -12,7 +18,7 @@ export class Tag {
   @Column({ default: true })
   isActive: boolean;
 
-  @Column({ type: "datetime", default: () => "CURRENT_TIMESTAMP" })
+  @CreateDateColumn()
   createdAt: Date;
 
   @ManyToMany(() => Post, (post) => post.tags)

--- a/server/src/config/entities/User.ts
+++ b/server/src/config/entities/User.ts
@@ -6,6 +6,7 @@ import {
   ManyToMany,
   ManyToOne,
   OneToOne,
+  CreateDateColumn,
 } from "typeorm";
 import { Post } from "./Post";
 import { Subscription } from "./Subscription";
@@ -55,4 +56,7 @@ export class User {
 
   @ManyToOne(() => DirectMessage, (directMessage) => directMessage.receiver)
   receivedMessages: DirectMessage[];
+
+  @CreateDateColumn()
+  createdAt: Date;
 }


### PR DESCRIPTION
Les formats de date sont incompatibles entre sqlite dev et postgres de la prod, on passe par CreateDateColumn pour résoudre ce pb car ça permet de choisir automatiquement entre les deux selon le type de db.

En passant je simplifie la commande de test docker pour permettre à tous de lancer et checker rapidement le site en environnement "prod" localement