### PR TITLE
68 multi sequence

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -23,9 +23,8 @@ const main = async () => {
   const server = createHttpServer(app);
   app
     .use(express.json())
-    .use(customSession())
     .use(cookieParser())
-    .use(express.json())
+    .use(customSession())
     .use(passport.initialize())
     .use(passport.session());
 

--- a/webapp/src/components/app/BloopNoteSequencer.vue
+++ b/webapp/src/components/app/BloopNoteSequencer.vue
@@ -823,29 +823,9 @@ const updateTempo = (): void => {
 };
 
 const playNotesAtPosition = (position: number): void => {
-  // 1. Démarrer les nouvelles notes à cette position
-  const notesToStart = layout.value.filter((note) => note.x === position);
-
-  notesToStart.forEach((note) => {
-    const noteName = getNoteFromY(note.y);
-
-    // Marquer la note comme active
-    activeNotes.value.add(note.i);
-
-    // Événement : Note commence (pour les instruments internes)
-    emit("noteStart", note, noteName, position);
-    _markNoteAsPlaying(note.i, true);
-
-    // Simuler appui clavier si activé (pour instruments qui écoutent le clavier)
-    if (enableKeyboardSimulation.value) {
-      midiStore.simulateKeyPress(noteName);
-    }
-
-    // eslint-disable-next-line no-console
-    console.info(`🎵 Start: ${noteName} (${note.i}) at position ${position}`);
-  });
-
-  // 2. Arrêter les notes qui se terminent à cette position
+  // 1. D'ABORD arrêter les notes qui se terminent à cette position
+  // IMPORTANT: On doit arrêter les notes AVANT d'en démarrer de nouvelles
+  // pour éviter un bug où deux notes identiques consécutives s'arrêtent mal
   const notesToStop = layout.value.filter((note) => {
     const endPosition = note.x + note.w;
     return endPosition === position && activeNotes.value.has(note.i);
@@ -868,6 +848,28 @@ const playNotesAtPosition = (position: number): void => {
 
     // eslint-disable-next-line no-console
     console.info(`🎵 End: ${noteName} (${note.i}) at position ${position}`);
+  });
+
+  // 2. ENSUITE démarrer les nouvelles notes à cette position
+  const notesToStart = layout.value.filter((note) => note.x === position);
+
+  notesToStart.forEach((note) => {
+    const noteName = getNoteFromY(note.y);
+
+    // Marquer la note comme active
+    activeNotes.value.add(note.i);
+
+    // Événement : Note commence (pour les instruments internes)
+    emit("noteStart", note, noteName, position);
+    _markNoteAsPlaying(note.i, true);
+
+    // Simuler appui clavier si activé (pour instruments qui écoutent le clavier)
+    if (enableKeyboardSimulation.value) {
+      midiStore.simulateKeyPress(noteName);
+    }
+
+    // eslint-disable-next-line no-console
+    console.info(`🎵 Start: ${noteName} (${note.i}) at position ${position}`);
   });
 };
 

--- a/webapp/src/components/app/BloopSequenceTabs.vue
+++ b/webapp/src/components/app/BloopSequenceTabs.vue
@@ -1,0 +1,577 @@
+<template>
+  <div class="sequence-tabs-container">
+    <!-- Header avec les onglets -->
+    <div class="tabs-header">
+      <div class="tabs-list">
+        <!-- Onglets des séquences -->
+        <div
+          v-for="sequence in sequencerStore.project.sequences"
+          :key="sequence.id"
+          class="tab"
+          :class="{ active: sequence.id === sequencerStore.project.activeSequenceId }"
+          @click="selectSequence(sequence.id)"
+          @contextmenu.prevent="showContextMenu($event, sequence)"
+        >
+          <span class="tab-name">{{ sequence.name }}</span>
+          <button
+            class="tab-close"
+            @click.stop="deleteSequence(sequence.id)"
+            v-if="sequencerStore.project.sequences.length > 1"
+            title="Supprimer la séquence"
+          >
+            ×
+          </button>
+        </div>
+
+        <!-- Bouton ajouter nouvelle séquence -->
+        <button class="tab-add" @click="createNewSequence" title="Nouvelle séquence">
+          +
+        </button>
+      </div>
+
+      <!-- Contrôles de projet -->
+      <div class="project-controls">
+        <input
+          v-model="projectName"
+          class="project-name-input"
+          :class="{ 'has-changes': projectStore.hasUnsavedChanges }"
+          @blur="updateProjectName"
+          @keyup.enter="updateProjectName"
+          placeholder="Nom du projet"
+          :title="projectStore.hasUnsavedChanges ? 'Projet modifié (non sauvegardé)' : 'Nom du projet'"
+        />
+        <div class="save-status" v-if="projectStore.hasUnsavedChanges" title="Changements non sauvegardés">
+          ●
+        </div>
+        <button @click="exportProject" class="btn btn-sm btn-success" title="Exporter le projet">
+          💾 Exporter
+        </button>
+        <button @click="importProject" class="btn btn-sm btn-info" title="Importer un projet">
+          📁 Importer
+        </button>
+      </div>
+    </div>
+
+    <!-- Menu contextuel -->
+    <div
+      v-if="contextMenu.visible"
+      class="context-menu"
+      :style="{ left: contextMenu.x + 'px', top: contextMenu.y + 'px' }"
+      @click="hideContextMenu"
+    >
+      <div class="context-item" @click="renameSequence(contextMenu.sequence?.id)">
+        ✏️ Renommer
+      </div>
+      <div class="context-item" @click="duplicateSequence(contextMenu.sequence?.id)">
+        📋 Dupliquer
+      </div>
+      <div
+        v-if="sequencerStore.project.sequences.length > 1"
+        class="context-item danger"
+        @click="deleteSequence(contextMenu.sequence?.id)"
+      >
+        🗑️ Supprimer
+      </div>
+    </div>
+
+    <!-- Modal de renommage -->
+    <div v-if="renameModal.visible" class="modal-overlay" @click="cancelRename">
+      <div class="modal" @click.stop>
+        <h3>Renommer la séquence</h3>
+        <input
+          ref="renameInput"
+          v-model="renameModal.newName"
+          class="rename-input"
+          @keyup.enter="confirmRename"
+          @keyup.escape="cancelRename"
+          placeholder="Nom de la séquence"
+        />
+        <div class="modal-buttons">
+          <button @click="cancelRename" class="btn btn-secondary">Annuler</button>
+          <button @click="confirmRename" class="btn btn-primary">Confirmer</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, nextTick, onMounted, onUnmounted, computed } from "vue";
+import { useSequencerStore } from "../../stores/sequencerStore";
+import { useProjectStore } from "../../stores/projectStore";
+import type { Sequence } from "../../lib/utils/types";
+
+const sequencerStore = useSequencerStore();
+const projectStore = useProjectStore();
+
+// Nom du projet (computed pour synchro)
+const projectName = computed({
+  get: () => sequencerStore.project.projectName,
+  set: (value: string) => {
+    sequencerStore.project.projectName = value;
+    sequencerStore.project.updatedAt = new Date();
+  },
+});
+
+// Menu contextuel
+const contextMenu = ref<{
+  visible: boolean;
+  x: number;
+  y: number;
+  sequence: Sequence | null;
+}>({
+  visible: false,
+  x: 0,
+  y: 0,
+  sequence: null,
+});
+
+// Modal de renommage
+const renameModal = ref<{
+  visible: boolean;
+  sequenceId: string | null;
+  newName: string;
+}>({
+  visible: false,
+  sequenceId: null,
+  newName: "",
+});
+
+const renameInput = ref<HTMLInputElement | null>(null);
+
+// Sélectionner une séquence
+const selectSequence = (sequenceId: string): void => {
+  sequencerStore.setActiveSequence(sequenceId);
+};
+
+// Créer une nouvelle séquence
+const createNewSequence = (): void => {
+  sequencerStore.createSequence();
+};
+
+// Supprimer une séquence
+const deleteSequence = (sequenceId: string | undefined): void => {
+  if (!sequenceId) return;
+  
+  const sequence = sequencerStore.project.sequences.find(s => s.id === sequenceId);
+  if (!sequence) return;
+
+  if (sequencerStore.project.sequences.length === 1) {
+    alert("Impossible de supprimer la dernière séquence.");
+    return;
+  }
+
+  if (confirm(`Êtes-vous sûr de vouloir supprimer la séquence "${sequence.name}" ?`)) {
+    sequencerStore.deleteSequence(sequenceId);
+  }
+  hideContextMenu();
+};
+
+// Afficher le menu contextuel
+const showContextMenu = (event: MouseEvent, sequence: Sequence): void => {
+  event.preventDefault();
+  contextMenu.value = {
+    visible: true,
+    x: event.clientX,
+    y: event.clientY,
+    sequence,
+  };
+};
+
+// Cacher le menu contextuel
+const hideContextMenu = (): void => {
+  contextMenu.value.visible = false;
+  contextMenu.value.sequence = null;
+};
+
+// Démarrer le renommage
+const renameSequence = (sequenceId: string | undefined): void => {
+  if (!sequenceId) return;
+  
+  const sequence = sequencerStore.project.sequences.find(s => s.id === sequenceId);
+  if (!sequence) return;
+
+  renameModal.value = {
+    visible: true,
+    sequenceId,
+    newName: sequence.name,
+  };
+
+  hideContextMenu();
+
+  nextTick(() => {
+    renameInput.value?.focus();
+    renameInput.value?.select();
+  });
+};
+
+// Confirmer le renommage
+const confirmRename = (): void => {
+  if (!renameModal.value.sequenceId || !renameModal.value.newName.trim()) return;
+
+  sequencerStore.renameSequence(renameModal.value.sequenceId, renameModal.value.newName.trim());
+  cancelRename();
+};
+
+// Annuler le renommage
+const cancelRename = (): void => {
+  renameModal.value.visible = false;
+  renameModal.value.sequenceId = null;
+  renameModal.value.newName = "";
+};
+
+// Dupliquer une séquence
+const duplicateSequence = (sequenceId: string | undefined): void => {
+  if (!sequenceId) return;
+  
+  const newId = sequencerStore.duplicateSequence(sequenceId);
+  if (newId) {
+    sequencerStore.setActiveSequence(newId);
+  }
+  hideContextMenu();
+};
+
+// Mettre à jour le nom du projet (plus besoin car computed)
+const updateProjectName = (): void => {
+  // La mise à jour se fait automatiquement via le computed setter
+};
+
+// Exporter le projet
+const exportProject = (): void => {
+  sequencerStore.exportProject();
+};
+
+// Importer un projet
+const importProject = async (): Promise<void> => {
+  // Vérifier s'il y a des changements non sauvegardés
+  if (projectStore.hasUnsavedChanges) {
+    if (!projectStore.confirmUnsavedChanges()) {
+      return;
+    }
+  }
+
+  if (sequencerStore.project.sequences.some(seq => seq.layout.length > 0)) {
+    if (!confirm("L'import va remplacer le projet actuel. Voulez-vous continuer ?")) {
+      return;
+    }
+  }
+
+  await sequencerStore.importProject();
+  // Le nom se met à jour automatiquement via le computed
+  
+  // Réinitialiser l'état du projectStore pour un nouveau projet
+  projectStore.createNewProject();
+};
+
+// Gestion des clics globaux pour fermer le menu contextuel
+const handleGlobalClick = (event: MouseEvent): void => {
+  if (contextMenu.value.visible) {
+    hideContextMenu();
+  }
+};
+
+onMounted(() => {
+  document.addEventListener("click", handleGlobalClick);
+});
+
+onUnmounted(() => {
+  document.removeEventListener("click", handleGlobalClick);
+});
+</script>
+
+<style scoped>
+.sequence-tabs-container {
+  background-color: #2a2a2a;
+  border-bottom: 2px solid #333;
+}
+
+.tabs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 15px;
+  height: 50px;
+}
+
+.tabs-list {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: 1;
+  overflow-x: auto;
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background-color: #333;
+  border: 1px solid #444;
+  border-bottom: none;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+  border-radius: 4px 4px 0 0;
+  max-width: 200px;
+}
+
+.tab:hover {
+  background-color: #3a3a3a;
+}
+
+.tab.active {
+  background-color: var(--color-primary);
+  color: white;
+  border-color: var(--color-primary);
+}
+
+.tab-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: #ccc;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tab.active .tab-name {
+  color: white;
+}
+
+.tab-close {
+  background: none;
+  border: none;
+  color: #999;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
+  transition: all 0.2s;
+}
+
+.tab-close:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.tab.active .tab-close {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.tab.active .tab-close:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+.tab-add {
+  background-color: #444;
+  border: 1px solid #555;
+  color: #ccc;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: all 0.2s;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.tab-add:hover {
+  background-color: var(--color-primary);
+  color: white;
+  border-color: var(--color-primary);
+}
+
+.project-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.project-name-input {
+  background-color: #333;
+  border: 1px solid #444;
+  color: white;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 14px;
+  width: 200px;
+  transition: border-color 0.2s;
+}
+
+.project-name-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.project-name-input.has-changes {
+  border-color: var(--color-warning);
+}
+
+.save-status {
+  color: var(--color-warning);
+  font-size: 18px;
+  line-height: 1;
+  margin-left: 5px;
+}
+
+.btn {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: all 0.2s;
+  font-size: 12px;
+}
+
+.btn-sm {
+  padding: 4px 8px;
+  font-size: 11px;
+}
+
+.btn-success {
+  background-color: var(--color-validate);
+  color: white;
+}
+
+.btn-success:hover {
+  background-color: var(--color-validate-hover);
+}
+
+.btn-info {
+  background-color: var(--color-success);
+  color: white;
+}
+
+.btn-info:hover {
+  background-color: var(--color-success-hover);
+}
+
+.btn-primary {
+  background-color: var(--color-primary);
+  color: white;
+}
+
+.btn-primary:hover {
+  background-color: var(--color-primary-hover);
+}
+
+.btn-secondary {
+  background-color: var(--color-secondary);
+  color: white;
+}
+
+.btn-secondary:hover {
+  background-color: var(--color-secondary-hover);
+}
+
+/* Menu contextuel */
+.context-menu {
+  position: fixed;
+  background-color: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  min-width: 150px;
+}
+
+.context-item {
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #ccc;
+  transition: background-color 0.2s;
+}
+
+.context-item:hover {
+  background-color: #3a3a3a;
+}
+
+.context-item.danger {
+  color: var(--color-error);
+}
+
+.context-item.danger:hover {
+  background-color: rgba(238, 53, 53, 0.1);
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.modal {
+  background-color: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 8px;
+  padding: 20px;
+  min-width: 300px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+
+.modal h3 {
+  margin: 0 0 15px 0;
+  color: white;
+  font-size: 16px;
+}
+
+.rename-input {
+  width: 100%;
+  background-color: #333;
+  border: 1px solid #444;
+  color: white;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-bottom: 15px;
+}
+
+.rename-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.modal-buttons {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .tabs-header {
+    flex-direction: column;
+    height: auto;
+    padding: 10px;
+    gap: 10px;
+  }
+
+  .project-controls {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .project-name-input {
+    width: 150px;
+  }
+
+  .tab {
+    max-width: 120px;
+  }
+}
+</style>

--- a/webapp/src/lib/utils/types.ts
+++ b/webapp/src/lib/utils/types.ts
@@ -41,6 +41,35 @@ export type NoteEndHandler = (
   position: number,
 ) => void;
 
+// Types pour la gestion multi-séquences
+export interface Sequence {
+  id: string;
+  name: string;
+  layout: MidiNote[];
+  tempo: number;
+  cols: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SequencerProject {
+  sequences: Sequence[];
+  activeSequenceId: string | null;
+  projectName: string;
+  version: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Format de sauvegarde compatible avec l'ancien système
+export interface LegacySequenceData {
+  layout: MidiNote[];
+  tempo: number;
+  cols: number;
+  timestamp: string;
+  version: string;
+}
+
 export type User = {
   id: string;
   email: string;

--- a/webapp/src/stores/projectStore.ts
+++ b/webapp/src/stores/projectStore.ts
@@ -181,7 +181,7 @@ export const useProjectStore = defineStore("project", () => {
       } else {
         // CREATE : Nouveau projet
         result = await apiClient.post<{ body: any }>("/app/projects", {
-          name: "Mon Projet Musical",
+          name: sequencerProject.projectName,
           description: "Projet créé avec BloopNoteSequencer",
           data: projectData,
         });

--- a/webapp/src/stores/projectStore.ts
+++ b/webapp/src/stores/projectStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 import apiClient from "../lib/utils/apiClient";
-import type { MidiNote, NoteName, SequencerProject } from "../lib/utils/types";
+import type { NoteName, SequencerProject } from "../lib/utils/types";
 
 export const useProjectStore = defineStore("project", () => {
   const isSaving = ref(false);
@@ -289,12 +289,13 @@ export const useProjectStore = defineStore("project", () => {
         if (sequencerState) {
           // Charger le projet complet avec toutes les séquences
           sequencerStore.loadProjectData(sequencerState);
-          
+
           enableKeyboardSimulation.value =
             projectData?.project?.current_state?.keyboard_simulation ?? true;
 
           // Mettre à jour nextNoteId pour éviter les conflits
-          const allNotes = sequencerState.sequences?.flatMap((seq: any) => seq.layout) || [];
+          const allNotes =
+            sequencerState.sequences?.flatMap((seq: any) => seq.layout) || [];
           const maxId = Math.max(
             0,
             ...allNotes
@@ -352,7 +353,10 @@ export const useProjectStore = defineStore("project", () => {
 
     if (lastSavedState.value && currentState !== lastSavedState.value) {
       hasUnsavedChanges.value = true;
-    } else if (!lastSavedState.value && sequencerProject.sequences.some(seq => seq.layout.length > 0)) {
+    } else if (
+      !lastSavedState.value &&
+      sequencerProject.sequences.some((seq) => seq.layout.length > 0)
+    ) {
       // Nouveau projet avec des modifications par rapport à l'état initial
       hasUnsavedChanges.value = true;
     }

--- a/webapp/src/stores/sequencerStore.ts
+++ b/webapp/src/stores/sequencerStore.ts
@@ -1,0 +1,423 @@
+import { defineStore } from "pinia";
+import { ref, computed, watch } from "vue";
+import type { Sequence, SequencerProject, MidiNote, LegacySequenceData } from "../lib/utils/types";
+
+const STORAGE_KEY = "bloop-sequencer-project";
+const DEFAULT_COLS = 64;
+const DEFAULT_TEMPO = 120;
+
+export const useSequencerStore = defineStore("sequencerStore", () => {
+  // État du projet
+  const project = ref<SequencerProject>({
+    sequences: [],
+    activeSequenceId: null,
+    projectName: "Mon Projet",
+    version: "2.0",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  // Computed pour la séquence active
+  const activeSequence = computed<Sequence | null>(() => {
+    if (!project.value.activeSequenceId) return null;
+    return project.value.sequences.find(
+      (seq) => seq.id === project.value.activeSequenceId
+    ) || null;
+  });
+
+  // Computed pour les propriétés de la séquence active (compatibilité avec le composant existant)
+  const layout = computed<MidiNote[]>({
+    get: () => activeSequence.value?.layout || [],
+    set: (newLayout: MidiNote[]) => {
+      if (activeSequence.value) {
+        activeSequence.value.layout = newLayout;
+        activeSequence.value.updatedAt = new Date();
+        project.value.updatedAt = new Date();
+      }
+    }
+  });
+
+  const tempo = computed<number>({
+    get: () => activeSequence.value?.tempo || DEFAULT_TEMPO,
+    set: (newTempo: number) => {
+      if (activeSequence.value) {
+        activeSequence.value.tempo = newTempo;
+        activeSequence.value.updatedAt = new Date();
+        project.value.updatedAt = new Date();
+      }
+    }
+  });
+
+  const cols = computed<number>(() => activeSequence.value?.cols || DEFAULT_COLS);
+
+  // Générer un ID unique
+  const generateId = (): string => {
+    return `seq_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  };
+
+  // Générer un ID unique pour une note
+  const generateNoteId = (sequenceId: string): string => {
+    return `${sequenceId}_note_${Date.now()}_${Math.random().toString(36).substr(2, 5)}`;
+  };
+
+  // Générer un nom unique pour une nouvelle séquence
+  const generateSequenceName = (): string => {
+    const baseName = "Séquence";
+    let counter = 1;
+    let name = `${baseName} ${counter}`;
+    
+    while (project.value.sequences.some(seq => seq.name === name)) {
+      counter++;
+      name = `${baseName} ${counter}`;
+    }
+    
+    return name;
+  };
+
+  // Créer une nouvelle séquence
+  const createSequence = (name?: string): string => {
+    const newSequence: Sequence = {
+      id: generateId(),
+      name: name || generateSequenceName(),
+      layout: [],
+      tempo: DEFAULT_TEMPO,
+      cols: DEFAULT_COLS,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    project.value.sequences.push(newSequence);
+    project.value.activeSequenceId = newSequence.id;
+    project.value.updatedAt = new Date();
+
+    return newSequence.id;
+  };
+
+  // Supprimer une séquence
+  const deleteSequence = (sequenceId: string): boolean => {
+    const index = project.value.sequences.findIndex(seq => seq.id === sequenceId);
+    if (index === -1) return false;
+
+    project.value.sequences.splice(index, 1);
+
+    // Si c'était la séquence active, sélectionner une autre ou null
+    if (project.value.activeSequenceId === sequenceId) {
+      if (project.value.sequences.length > 0) {
+        project.value.activeSequenceId = project.value.sequences[0].id;
+      } else {
+        project.value.activeSequenceId = null;
+      }
+    }
+
+    project.value.updatedAt = new Date();
+    return true;
+  };
+
+  // Renommer une séquence
+  const renameSequence = (sequenceId: string, newName: string): boolean => {
+    const sequence = project.value.sequences.find(seq => seq.id === sequenceId);
+    if (!sequence) return false;
+
+    sequence.name = newName;
+    sequence.updatedAt = new Date();
+    project.value.updatedAt = new Date();
+    return true;
+  };
+
+  // Dupliquer une séquence
+  const duplicateSequence = (sequenceId: string): string | null => {
+    const sequence = project.value.sequences.find(seq => seq.id === sequenceId);
+    if (!sequence) return null;
+
+    const newSequence: Sequence = {
+      id: generateId(),
+      name: `${sequence.name} (copie)`,
+      layout: JSON.parse(JSON.stringify(sequence.layout)), // Deep copy
+      tempo: sequence.tempo,
+      cols: sequence.cols,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    project.value.sequences.push(newSequence);
+    project.value.updatedAt = new Date();
+    return newSequence.id;
+  };
+
+  // Changer la séquence active
+  const setActiveSequence = (sequenceId: string | null): boolean => {
+    if (sequenceId === null) {
+      project.value.activeSequenceId = null;
+      return true;
+    }
+
+    const sequence = project.value.sequences.find(seq => seq.id === sequenceId);
+    if (!sequence) return false;
+
+    project.value.activeSequenceId = sequenceId;
+    return true;
+  };
+
+  // Réorganiser les séquences
+  const reorderSequences = (fromIndex: number, toIndex: number): boolean => {
+    if (fromIndex < 0 || toIndex < 0 || 
+        fromIndex >= project.value.sequences.length || 
+        toIndex >= project.value.sequences.length) {
+      return false;
+    }
+
+    const [removed] = project.value.sequences.splice(fromIndex, 1);
+    project.value.sequences.splice(toIndex, 0, removed);
+    project.value.updatedAt = new Date();
+    return true;
+  };
+
+  // Sauvegarder dans localStorage
+  const saveToLocalStorage = (): void => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(project.value));
+    } catch (error) {
+      console.error("Erreur lors de la sauvegarde locale:", error);
+    }
+  };
+
+  // Charger depuis localStorage
+  const loadFromLocalStorage = (): boolean => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (!saved) return false;
+
+      const data = JSON.parse(saved) as SequencerProject;
+      
+      // Validation basique
+      if (!data.sequences || !Array.isArray(data.sequences)) return false;
+
+      // Convertir les dates
+      data.createdAt = new Date(data.createdAt);
+      data.updatedAt = new Date(data.updatedAt);
+      data.sequences.forEach(seq => {
+        seq.createdAt = new Date(seq.createdAt);
+        seq.updatedAt = new Date(seq.updatedAt);
+      });
+
+      project.value = data;
+      return true;
+    } catch (error) {
+      console.error("Erreur lors du chargement local:", error);
+      return false;
+    }
+  };
+
+  // Exporter le projet complet
+  const exportProject = (): void => {
+    const dataStr = JSON.stringify(project.value, null, 2);
+    const dataBlob = new Blob([dataStr], { type: "application/json" });
+
+    const link = document.createElement("a");
+    link.href = URL.createObjectURL(dataBlob);
+    link.download = `${project.value.projectName.replace(/[^a-z0-9]/gi, '_')}-${new Date().toISOString().split("T")[0]}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
+  };
+
+  // Importer un projet (supporte l'ancien format et le nouveau)
+  const importProject = (): Promise<boolean> => {
+    return new Promise((resolve) => {
+      const input = document.createElement("input");
+      input.type = "file";
+      input.accept = ".json";
+
+      input.onchange = (event: Event) => {
+        const file = (event.target as HTMLInputElement).files?.[0];
+        if (!file) {
+          resolve(false);
+          return;
+        }
+
+        const reader = new FileReader();
+        reader.onload = (e: ProgressEvent<FileReader>) => {
+          try {
+            const content = e.target?.result as string;
+            const data = JSON.parse(content);
+
+            // Détecter le format
+            if (data.sequences && Array.isArray(data.sequences)) {
+              // Nouveau format multi-séquences
+              loadProjectData(data);
+            } else if (data.layout && Array.isArray(data.layout)) {
+              // Ancien format single-séquence
+              importLegacySequence(data);
+            } else {
+              throw new Error("Format de fichier non reconnu");
+            }
+
+            resolve(true);
+          } catch (error) {
+            console.error("Erreur lors de l'import:", error);
+            alert("Erreur lors du chargement du fichier. Vérifiez le format JSON.");
+            resolve(false);
+          }
+        };
+
+        reader.readAsText(file);
+      };
+
+      document.body.appendChild(input);
+      input.click();
+      document.body.removeChild(input);
+    });
+  };
+
+  // Détecter si c'est un projet avec l'ancien système de notes
+  const isLegacyNoteSystem = (sequences: any[]): boolean => {
+    // Vérifier si des notes ont des coordonnées Y > 35 (ancien système avait 36 notes max)
+    return sequences.some(seq => 
+      seq.layout?.some((note: any) => note.y >= 36)
+    ) === false && sequences.some(seq => seq.layout?.length > 0);
+  };
+
+  // Migration des coordonnées Y de l'ancien système (36 notes) vers le nouveau (87 notes)
+  const migrateNoteCoordinates = (oldY: number): number => {
+    // Ancien système : C6 à C#3 (36 notes)
+    const oldNotes = [
+      "C6", "B5", "A#5", "A5", "G#5", "G5", "F#5", "F5", "E5", "D#5", "D5", "C#5", "C5",
+      "B4", "A#4", "A4", "G#4", "G4", "F#4", "F4", "E4", "D#4", "D4", "C#4", "C4",
+      "B3", "A#3", "A3", "G#3", "G3", "F#3", "F3", "E3", "D#3", "D3", "C#3"
+    ];
+    
+    // Nouveau système : C8 à A0 (87 notes)
+    const newNotes = [
+      "C8",
+      "B7", "A#7", "A7", "G#7", "G7", "F#7", "F7", "E7", "D#7", "D7", "C#7", "C7",
+      "B6", "A#6", "A6", "G#6", "G6", "F#6", "F6", "E6", "D#6", "D6", "C#6", "C6",
+      "B5", "A#5", "A5", "G#5", "G5", "F#5", "F5", "E5", "D#5", "D5", "C#5", "C5",
+      "B4", "A#4", "A4", "G#4", "G4", "F#4", "F4", "E4", "D#4", "D4", "C#4", "C4",
+      "B3", "A#3", "A3", "G#3", "G3", "F#3", "F3", "E3", "D#3", "D3", "C#3", "C3",
+      "B2", "A#2", "A2", "G#2", "G2", "F#2", "F2", "E2", "D#2", "D2", "C#2", "C2",
+      "B1", "A#1", "A1", "G#1", "G1", "F#1", "F1", "E1", "D#1", "D1", "C#1", "C1",
+      "B0", "A#0", "A0"
+    ];
+
+    // Si l'ancien Y est valide, trouver la note correspondante et sa nouvelle position
+    if (oldY >= 0 && oldY < oldNotes.length) {
+      const noteName = oldNotes[oldY];
+      const newIndex = newNotes.findIndex(n => n === noteName);
+      return newIndex >= 0 ? newIndex : oldY; // Fallback vers oldY si pas trouvé
+    }
+    
+    return oldY; // Retourner l'ancienne valeur si hors limites
+  };
+
+  // Charger les données d'un projet (fonction publique)
+  const loadProjectData = (data: any): void => {
+    const newProject: SequencerProject = {
+      sequences: data.sequences || [],
+      activeSequenceId: data.activeSequenceId || null,
+      projectName: data.projectName || "Projet Importé",
+      version: data.version || "2.0",
+      createdAt: new Date(data.createdAt || new Date()),
+      updatedAt: new Date(data.updatedAt || new Date()),
+    };
+
+    // Détecter si c'est un projet avec l'ancien système de notes
+    const needsMigration = isLegacyNoteSystem(newProject.sequences);
+
+    // Convertir les dates des séquences et s'assurer que les IDs des notes sont uniques
+    newProject.sequences.forEach(seq => {
+      seq.createdAt = new Date(seq.createdAt);
+      seq.updatedAt = new Date(seq.updatedAt);
+      
+      // Régénérer les IDs des notes et migrer les coordonnées Y si nécessaire
+      seq.layout.forEach((note, index) => {
+        // Migrer les coordonnées Y de l'ancien système vers le nouveau si nécessaire
+        if (needsMigration) {
+          const oldY = note.y;
+          note.y = migrateNoteCoordinates(oldY);
+          console.log(`Migrated note Y from ${oldY} to ${note.y}`);
+        }
+        
+        // Régénérer les IDs pour éviter les doublons entre séquences
+        note.i = generateNoteId(seq.id) + `_${index}`;
+      });
+    });
+
+    project.value = newProject;
+
+    // Si aucune séquence active et qu'il y en a, prendre la première
+    if (!project.value.activeSequenceId && project.value.sequences.length > 0) {
+      project.value.activeSequenceId = project.value.sequences[0].id;
+    }
+  };
+
+  // Importer une séquence au format legacy
+  const importLegacySequence = (data: LegacySequenceData): void => {
+    // Créer une nouvelle séquence à partir des données legacy
+    const newSequence: Sequence = {
+      id: generateId(),
+      name: "Séquence Importée",
+      layout: data.layout,
+      tempo: data.tempo || DEFAULT_TEMPO,
+      cols: data.cols || DEFAULT_COLS,
+      createdAt: new Date(data.timestamp || new Date()),
+      updatedAt: new Date(),
+    };
+
+    project.value.sequences.push(newSequence);
+    project.value.activeSequenceId = newSequence.id;
+    project.value.updatedAt = new Date();
+  };
+
+  // Initialiser avec une séquence par défaut si vide
+  const initialize = (): void => {
+    // Essayer de charger depuis localStorage
+    if (!loadFromLocalStorage()) {
+      // Si rien en localStorage, créer une séquence par défaut
+      createSequence("Ma Première Séquence");
+    }
+
+    // S'assurer qu'il y a toujours au moins une séquence
+    if (project.value.sequences.length === 0) {
+      createSequence("Ma Première Séquence");
+    }
+
+    // S'assurer qu'il y a une séquence active
+    if (!project.value.activeSequenceId && project.value.sequences.length > 0) {
+      project.value.activeSequenceId = project.value.sequences[0].id;
+    }
+  };
+
+  // Auto-sauvegarde quand le project change
+  watch(project, saveToLocalStorage, { deep: true });
+
+  return {
+    // État
+    project,
+    activeSequence,
+    layout,
+    tempo,
+    cols,
+
+    // Actions pour les séquences
+    createSequence,
+    deleteSequence,
+    renameSequence,
+    duplicateSequence,
+    setActiveSequence,
+    reorderSequences,
+
+    // Sauvegarde/Chargement
+    saveToLocalStorage,
+    loadFromLocalStorage,
+    loadProjectData,
+    exportProject,
+    importProject,
+
+    // Utilitaires
+    generateNoteId,
+
+    // Initialisation
+    initialize,
+  };
+});

--- a/webapp/src/stores/sequencerStore.ts
+++ b/webapp/src/stores/sequencerStore.ts
@@ -271,9 +271,15 @@ export const useSequencerStore = defineStore("sequencerStore", () => {
   };
 
   // Détecter si c'est un projet avec l'ancien système de notes
-  const isLegacyNoteSystem = (sequences: any[]): boolean => {
-    // Vérifier si des notes ont des coordonnées Y > 35 (ancien système avait 36 notes max)
-    return sequences.some(seq => 
+  const isLegacyNoteSystem = (version: string | undefined, sequences: any[]): boolean => {
+    // Si la version est explicitement "2.0", c'est le nouveau système
+    if (version === "2.0") {
+      return false;
+    }
+
+    // Si la version est absente ou différente, vérifier avec les coordonnées Y
+    // Ancien système avait 36 notes max (y de 0 à 35)
+    return sequences.some(seq =>
       seq.layout?.some((note: any) => note.y >= 36)
     ) === false && sequences.some(seq => seq.layout?.length > 0);
   };
@@ -322,7 +328,7 @@ export const useSequencerStore = defineStore("sequencerStore", () => {
     };
 
     // Détecter si c'est un projet avec l'ancien système de notes
-    const needsMigration = isLegacyNoteSystem(newProject.sequences);
+    const needsMigration = isLegacyNoteSystem(data.version, newProject.sequences);
 
     // Convertir les dates des séquences et s'assurer que les IDs des notes sont uniques
     newProject.sequences.forEach(seq => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce multi-sequence project workflow with tabs and a new sequencer store, expand piano roll to 88 keys, and update project save/load to handle multi-sequence data.
> 
> - **Sequencer UI/UX**:
>   - Add `BloopSequenceTabs` for multi-sequence tabs (create, rename, duplicate, delete), project name editing, and import/export.
>   - Update `BloopNoteSequencer.vue` to depend on `useSequencerStore`, gate UI when no active sequence, and remove legacy local save/load buttons.
>   - Expand note range to full 88-key piano, add octave markers/labels, tweak grid heights, and minor selection/drag UX.
>   - Playback fix: stop notes before starting new ones at the same position.
> - **State Management & Persistence**:
>   - New `useSequencerStore` managing `SequencerProject` with multiple `Sequence`s, active sequence, note ID generation, localStorage autosave, and import/export (with legacy format migration).
>   - Refactor `useProjectStore` to save/load full multi-sequence projects; generate tracks per sequence; update change detection and URL-based loading.
> - **Server**:
>   - Adjust middleware order in `server/src/main.ts` (remove duplicate `express.json`, move `customSession` after `cookieParser`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd8950be93f135d9c22716928db34a7c94646a7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->